### PR TITLE
enforce python3 and weird utf-8 encoding for description

### DIFF
--- a/tplink-util.py
+++ b/tplink-util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Copyright 2013 Kevin Rauwolf
@@ -115,6 +115,6 @@ if __name__ == '__main__':
         ip, mac, model, description = struct.unpack(kResponseFormat, responses[addr])
         ip = socket.inet_ntoa(ip)
         mac = ':'.join('{:02x}'.format(part) for part in mac)
-        model = model.decode('utf-8')
-        description = description.decode('utf-8')
+        model = model.decode('utf-8', errors='replace')
+        description = description.decode('utf-8', errors='replace')
         print(kReportFormat.format(ip, mac, model, description))


### PR DESCRIPTION
Hello,

Even if a native client exists for OSX, I prefer using your Python script.

I just added an option for the utf-8 decoding. my device returns this (in French):

(wireshark capture)
000001e0  34 32 32 30 00 00 00 00  00 00 00 00 00 00 50 6f  |4220..........Po|
000001f0  69 6e 74 20 64 a1 af 61  63 63 a8 a8 73 20 43 50  |int d..acc..s CP|

0xa8 0xa8 is not the UTF-8 encoding for è (actually: C3 A8)
0xa1 0xaf should stand for a kind of an apostrophe...

Regards and best wishes for 2016 !
rené
